### PR TITLE
Fix crashes when llvm::Function is empty.

### DIFF
--- a/parser/createBlocks.cpp
+++ b/parser/createBlocks.cpp
@@ -7,6 +7,9 @@ void createBlocks(const llvm::Module* module, Program& program) {
     assert(program.isPassCompleted(PassType::CreateFunctions));
 
     for (const llvm::Function& func : module->functions()) {
+        if (func.size() == 0)
+            continue;
+
         auto* function = program.getFunction(&func);
         for (const auto& block : func) {
             function->createBlockIfNotExist(&block);

--- a/parser/findMetadataFunctionNames.cpp
+++ b/parser/findMetadataFunctionNames.cpp
@@ -10,7 +10,11 @@ void findMetadataFunctionNames(const llvm::Module* module, Program& program) {
     assert(program.isPassCompleted(PassType::CreateFunctions));
 
     for (const llvm::Function& func : module->functions()) {
+        if (func.isDeclaration())
+            continue;
+
         auto function = program.getFunction(&func);
+        assert(function && "Do not have function");
 
         function->fillMetadataVarNames(program.getGlobalVarNames());
 


### PR DESCRIPTION
Fixes also #29 .